### PR TITLE
[dev-plugins] Allow panes to scroll as content expands

### DIFF
--- a/packages/apollo-client/webui/src/App.tsx
+++ b/packages/apollo-client/webui/src/App.tsx
@@ -122,8 +122,10 @@ const styles = StyleSheet.create({
   sider: {
     backgroundColor: '#fff',
     padding: 8,
+    overflow: 'scroll',
   },
   content: {
     padding: 8,
+    overflow: 'scroll'
   },
 });

--- a/packages/react-navigation/webui/src/Logs.tsx
+++ b/packages/react-navigation/webui/src/Logs.tsx
@@ -33,7 +33,7 @@ export function Logs({ active, logs, index, resetTo }: Props) {
 
   return logs.length ? (
     <Layout hasSider={hasSider}>
-      <Layout.Content>
+      <Layout.Content style={{ height: '100vh', overflow: 'auto'}}>
         <AutoSizer>
           {({ height, width }) => (
             <List

--- a/packages/react-navigation/webui/src/Sidebar.tsx
+++ b/packages/react-navigation/webui/src/Sidebar.tsx
@@ -24,6 +24,8 @@ export function Sidebar({
         margin: `0 ${theme.space.medium}px`,
         padding: `0 ${theme.space.small}px`,
         borderRadius: theme.borderRadius,
+        overflow: 'auto',
+        height: '100vh'
       }}>
       {stack ? (
         <>

--- a/packages/react-query/webui/src/components/QuerySidebar.tsx
+++ b/packages/react-query/webui/src/components/QuerySidebar.tsx
@@ -64,7 +64,7 @@ export default function QuerySidebar({ query, onQueryRefetch, onQueryRemove }: P
   ];
 
   return (
-    <Layout.Sider width="30%" theme="light">
+    <Layout.Sider style={{ height: '100vh', overflow: 'auto' }} width="30%" theme="light">
       <Collapse items={panels} bordered={false} />
     </Layout.Sider>
   );


### PR DESCRIPTION
While testing devtools plugins, I found that I could not scroll when the values were large or the lists of events were long. Tried adding scrolling wherever I could create enough data that scrolling was needed:

- React Navigation: tested scrolling on list of events and state side pane
- Apollo Client: testing scrolling on list of events and side pane
- React Query: tested scrolling on side pane. It looks like the list of events has pagination, so scrolling may not be needed
- Tinybase: the entire web ui is an external component, so it likely does not need this change