### PR TITLE
[packages] inline process.env.NODE_ENV types

### DIFF
--- a/packages/apollo-client/src/index.ts
+++ b/packages/apollo-client/src/index.ts
@@ -1,3 +1,11 @@
+declare global {
+  const process: {
+    env: {
+      NODE_ENV: 'development' | 'production';
+    };
+  };
+}
+
 export let useApolloClientDevTools: typeof import('./useApolloClientDevTools').useApolloClientDevTools;
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/apollo-client/src/ts-declarations/process.d.ts
+++ b/packages/apollo-client/src/ts-declarations/process.d.ts
@@ -1,5 +1,0 @@
-declare const process: {
-  env: {
-    NODE_ENV: string;
-  };
-};

--- a/packages/react-navigation/src/index.ts
+++ b/packages/react-navigation/src/index.ts
@@ -1,3 +1,11 @@
+declare global {
+  const process: {
+    env: {
+      NODE_ENV: 'development' | 'production';
+    };
+  };
+}
+
 export let useReactNavigationDevTools: typeof import('./useReactNavigationDevTools').useReactNavigationDevTools;
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-navigation/src/ts-declarations/process.d.ts
+++ b/packages/react-navigation/src/ts-declarations/process.d.ts
@@ -1,5 +1,0 @@
-declare const process: {
-  env: {
-    NODE_ENV: string;
-  };
-};

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -1,3 +1,11 @@
+declare global {
+  const process: {
+    env: {
+      NODE_ENV: 'development' | 'production';
+    };
+  };
+}
+
 export let useReactQueryDevTools: typeof import('./useReactQueryDevTools').useReactQueryDevTools;
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-query/src/ts-declarations/process.d.ts
+++ b/packages/react-query/src/ts-declarations/process.d.ts
@@ -1,5 +1,0 @@
-declare const process: {
-  env: {
-    NODE_ENV: string;
-  };
-};

--- a/packages/tinybase/src/index.ts
+++ b/packages/tinybase/src/index.ts
@@ -1,3 +1,11 @@
+declare global {
+  const process: {
+    env: {
+      NODE_ENV: 'development' | 'production';
+    };
+  };
+}
+
 export let useTinyBaseDevTools: typeof import('./useTinyBaseDevTools').useTinyBaseDevTools;
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/tinybase/src/ts-declarations/process.d.ts
+++ b/packages/tinybase/src/ts-declarations/process.d.ts
@@ -1,5 +1,0 @@
-declare const process: {
-  env: {
-    NODE_ENV: string;
-  };
-};


### PR DESCRIPTION
# Why

cleanup external type declaration files and inline the `process.env.NODE_ENV` type because we don't use it across different files