### PR TITLE
fix[async-storage]: Scrolling on the Y axis

### DIFF
--- a/packages/async-storage/webui/src/App.tsx
+++ b/packages/async-storage/webui/src/App.tsx
@@ -3,7 +3,7 @@ import { AsyncStorageTable } from './AsyncStorageTable';
 
 export default function Main() {
   return (
-    <App style={{ width: '100%', height: '100%', padding: '0.75em' }}>
+    <App style={{ width: '100%', height: '100%', padding: '0.75em', overflowY: 'scroll' }}>
       <AsyncStorageTable />
       <p>
         By default, the reload button will not update any fields you have changed. To fully update


### PR DESCRIPTION
Was playing around with the plugin in one of my projects, noticed that it was not possible to scroll when the list was long.