### PR TITLE
[react-query]: Fix QuerySidebar being rendered outside of view

### DIFF
--- a/packages/react-query/webui/src/App.tsx
+++ b/packages/react-query/webui/src/App.tsx
@@ -159,7 +159,7 @@ export default function App() {
   );
 
   return (
-    <Layout hasSider={true}>
+    <StyledLayout hasSider={true}>
       <Content>
         <Table<ExtendedQuery>
           dataSource={queries}
@@ -181,9 +181,13 @@ export default function App() {
         onQueryRefetch={handleQueryRefetch}
         onQueryRemove={handleQueryRemove}
       />
-    </Layout>
+    </StyledLayout>
   );
 }
+
+const StyledLayout = styled(Layout)({
+  maxWidth: '100%',
+});
 
 const Content = styled(Layout.Content)({
   margin: '0 16px',


### PR DESCRIPTION
I was checking out the react-query devtools and noticed that the `QuerySidebar` disappeared for some queries. Seems to be related to the Data Explorer and the `request._response` property in the axios response schema. If this contains a very large string, the `QuerySidebar` somehow gets pushed outside of the view (perhaps because Ant Design expects the `Layout.Sider` to be on the left side?). 