### PR TITLE
fix: Added Default collapsed to ReactJson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# misc
+.idea

--- a/packages/apollo-client/webui/src/Details.tsx
+++ b/packages/apollo-client/webui/src/Details.tsx
@@ -34,7 +34,7 @@ export function Details({ selectedItem }: { selectedItem: BlockType }) {
               <Typography.Title level={4} type="secondary">
                 {block?.blockLabel}
               </Typography.Title>
-              <ReactJson src={block?.blockValue} />
+              <ReactJson src={block?.blockValue} collapsed/>
               <br />
             </Fragment>
           );

--- a/packages/react-navigation/webui/src/Sidebar.tsx
+++ b/packages/react-navigation/webui/src/Sidebar.tsx
@@ -78,9 +78,9 @@ export function Sidebar({
         </>
       ) : null}
       <Title4>Action</Title4>
-      <ReactJson src={action} />
+      <ReactJson src={action} collapsed />
       <Title4>State</Title4>
-      <ReactJson src={state ?? {}} />
+      <ReactJson src={state ?? {}} collapsed />
     </Layout.Sider>
   );
 }

--- a/packages/react-query/webui/src/components/QuerySidebar.tsx
+++ b/packages/react-query/webui/src/components/QuerySidebar.tsx
@@ -48,7 +48,7 @@ export default function QuerySidebar({ query, onQueryRefetch, onQueryRemove }: P
       label: 'Data Explorer',
       children: (
         <ContainerWithPaddings>
-          {<ReactJson src={query?.state?.data || {}} enableClipboard={false} />}
+          {<ReactJson src={query?.state?.data || {}} enableClipboard={false} collapsed />}
         </ContainerWithPaddings>
       ),
     },
@@ -57,7 +57,7 @@ export default function QuerySidebar({ query, onQueryRefetch, onQueryRemove }: P
       label: 'Query Explorer',
       children: (
         <ContainerWithPaddings>
-          <ReactJson src={query || {}} enableClipboard={false} />
+          <ReactJson src={query || {}} enableClipboard={false} collapsed />
         </ContainerWithPaddings>
       ),
     },


### PR DESCRIPTION
Noticed that when I open the `Query Explorer` the app crashes if the data is very big.

<img width="741" alt="image" src="https://github.com/expo/dev-plugins/assets/4567644/843ecf58-9bff-483e-b812-8e70c362c45f">

I added `collapsed` based on the docs from https://www.npmjs.com/package/react-json-view so no data initial data is loaded to all <ReactJson> to prevent a crash