### PR TITLE
[async-storage]: Fix inline editing cursor jump

### DIFF
--- a/packages/async-storage/webui/src/AsyncStorageTable.tsx
+++ b/packages/async-storage/webui/src/AsyncStorageTable.tsx
@@ -95,8 +95,8 @@ export function AsyncStorageTable() {
                 },
               };
             },
-            shouldCellUpdate(record, prevRecord) {
-              return record.editedValue !== prevRecord.editedValue;
+            shouldCellUpdate() {
+              return false;
             },
           },
           {

--- a/packages/async-storage/webui/src/AsyncStorageTable.tsx
+++ b/packages/async-storage/webui/src/AsyncStorageTable.tsx
@@ -103,7 +103,7 @@ export function AsyncStorageTable() {
               };
             },
             shouldCellUpdate(record, prevRecord) {
-              return !editingManually && record.editedValue !== prevRecord.editedValue
+              return !editingManually && record.editedValue !== prevRecord.editedValue;
             },
           },
           {

--- a/packages/async-storage/webui/src/AsyncStorageTable.tsx
+++ b/packages/async-storage/webui/src/AsyncStorageTable.tsx
@@ -25,6 +25,7 @@ export function AsyncStorageTable() {
   const { showAddEntryDialog, AddEntryDialog, showing } = useAddEntryDialog({ set });
 
   const [initialUpdate, setInitialUpdate] = useState(false);
+  const [editingManually, setEditingManually] = useState(false);
   useEffect(() => {
     if (!initialUpdate && ready) {
       update()
@@ -93,10 +94,16 @@ export function AsyncStorageTable() {
                 onInput(e) {
                   updateInProgressEdits({ [record.key]: e.currentTarget.textContent });
                 },
+                onBlur() {
+                  setEditingManually(false)
+                },
+                onFocus() {
+                  setEditingManually(true)
+                }
               };
             },
-            shouldCellUpdate() {
-              return false;
+            shouldCellUpdate(record, prevRecord) {
+              return !editingManually && record.editedValue !== prevRecord.editedValue
             },
           },
           {


### PR DESCRIPTION
When attempting to update a value through async storage devtools UI, the cursor is moved to the beginning of the text input. 

This change disables re-rendering of the Value column cells as the user is typing. This issue no longer appears, and functionality of saving changes, adding and removing key-value pairs does not appear to be affected by this change. 

Fixes #23 