### PR TITLE
[react-query] Add support to show data that is not JSON

### DIFF
--- a/packages/react-query/webui/src/components/DataViewer.tsx
+++ b/packages/react-query/webui/src/components/DataViewer.tsx
@@ -1,8 +1,11 @@
 import ReactJson from 'react-json-view';
 
 export default function DataViewer({ src }: { src: unknown }) {
-  if (typeof src !== 'object' || src === null) {
-    return <ReactJson src={{ __default: src }} enableClipboard={false} collapsed />;
+  if (src === null || src === undefined) {
+    return <span>{src}</span>;
   }
-  return <ReactJson src={src} enableClipboard={false} collapsed />;
+  if (typeof src === 'object') {
+    return <ReactJson src={src} enableClipboard={false} collapsed />;
+  }
+  return <span>{src.toString()}</span>;
 }

--- a/packages/react-query/webui/src/components/DataViewer.tsx
+++ b/packages/react-query/webui/src/components/DataViewer.tsx
@@ -1,0 +1,8 @@
+import ReactJson from 'react-json-view';
+
+export default function DataViewer({ src }: { src: unknown }) {
+  if (typeof src !== 'object' || src === null) {
+    return <ReactJson src={{ __default: src }} enableClipboard={false} collapsed />;
+  }
+  return <ReactJson src={src} enableClipboard={false} collapsed />;
+}

--- a/packages/react-query/webui/src/components/QuerySidebar.tsx
+++ b/packages/react-query/webui/src/components/QuerySidebar.tsx
@@ -2,6 +2,7 @@ import { Button, Collapse, type CollapseProps, Layout, Space } from 'antd';
 import styled from '@emotion/styled';
 import ReactJson from 'react-json-view';
 import type { ExtendedQuery } from '../types';
+import DataViewer from './DataViewer';
 
 const ContainerWithPaddings = styled(Layout)({
   padding: '10px 5px',
@@ -48,7 +49,7 @@ export default function QuerySidebar({ query, onQueryRefetch, onQueryRemove }: P
       label: 'Data Explorer',
       children: (
         <ContainerWithPaddings>
-          {<ReactJson src={query?.state?.data || {}} enableClipboard={false} collapsed />}
+          <DataViewer src={query?.state?.data || {}}  />
         </ContainerWithPaddings>
       ),
     },


### PR DESCRIPTION
Currently the Data Explorer can only show JSON data. It fails on string, number, ... .
I am not sure if that is the best way or we should just show plain text/number without `react-json-view`.

before:
![before](https://github.com/expo/dev-plugins/assets/18392496/75dcb49d-ec53-4235-9300-1f4ab7fe6b19)


after:
<img width="211" alt="Screenshot 2024-06-19 at 22 48 59" src="https://github.com/expo/dev-plugins/assets/18392496/4a148e32-055a-4c94-a6c3-299ed24b4d78">





EDIT:
(removed this picture because creating a json is misleading if the data is not an object)
<img width="371" alt="after" src="https://github.com/expo/dev-plugins/assets/18392496/f415bcd5-167b-4f34-ae91-402679c73188">
