### PR TITLE
Add file-explorer-expo-dev-plugin to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@
 
   - Credit: [Matt Oakes](https://mattoakes.net) and based [Redux DevTools](https://github.com/reduxjs/redux-devtools/)
 
+- [`file-explorer-expo-dev-plugin`](https://github.com/dmt-op/file-explorer-expo-dev-plugin): Plugin for debugging [expo-file-system](https://github.com/expo/expo/tree/sdk-52/packages/expo-file-system) operations
+
+  - Credit: [Dmytro Kulahin](https://github.com/dmt-op)
+
 ## Contributions
 
 Due to the current bandwidth limitations of our team, we are unable to accept new plugin pull requests in this repository. We recommend developers to create and maintain their plugins in their own npm accounts.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
   - Credit: [Matt Oakes](https://mattoakes.net) and based [Redux DevTools](https://github.com/reduxjs/redux-devtools/)
 
-- [`file-explorer-expo-dev-plugin`](https://github.com/dmt-op/file-explorer-expo-dev-plugin): Plugin for debugging [expo-file-system](https://github.com/expo/expo/tree/sdk-52/packages/expo-file-system) operations
+- [`file-explorer-expo-dev-plugin`](https://github.com/dmt-op/file-explorer-expo-dev-plugin): Plugin for debugging [expo-file-system](https://docs.expo.dev/versions/latest/sdk/filesystem/) operations
 
   - Credit: [Dmytro Kulahin](https://github.com/dmt-op)
 


### PR DESCRIPTION
I've created a dev plugin that simplifies debugging file system operations. It's useful for Windows devs like me, as it enables file system access in Expo Go prototypes on iOS

Changes:
- Added the plugin to the list