### PR TITLE
[create-dev-plugin] fix issues and add build-webui script

### DIFF
--- a/packages/create-dev-plugin/src/createWebUiProject.ts
+++ b/packages/create-dev-plugin/src/createWebUiProject.ts
@@ -54,10 +54,14 @@ export async function createWebUiProjectAsync(
   debug(`Installing packages by ${packageManager}`);
   await installDependenciesAsync(webUiRoot, packageManager, { silent: true });
   debug(`Installing web packages`);
-  await spawnAsync('npx', ['expo', 'install', 'react-native-web', 'react-dom'], {
-    cwd: webUiRoot,
-    stdio: 'ignore',
-  });
+  await spawnAsync(
+    'npx',
+    ['expo', 'install', 'react-native-web', 'react-dom', '@expo/metro-runtime'],
+    {
+      cwd: webUiRoot,
+      stdio: 'ignore',
+    }
+  );
 
   // [4] Overwrite App.tsx
   await fs.writeFile(path.join(webUiRoot, 'App.tsx'), createAppEntryPointContent(projectInfo));

--- a/packages/create-dev-plugin/templates/app-adapter/package.json
+++ b/packages/create-dev-plugin/templates/app-adapter/package.json
@@ -7,12 +7,12 @@
   "sideEffects": false,
   "scripts": {
     "build": "expo-module build",
-    "build:all": "expo-module prepare && cd webui && npx expo export -p web --output-dir dist && mv dist ../dist",
+    "build:all": "expo-module prepare && <%- packageManager %> run web:export",
     "clean": "expo-module clean",
     "prepare": "expo-module prepare",
-    "prepublishOnly": "expo-module prepare && expo-module prepublishOnly && cd webui && npx expo export -p web --output-dir dist && mv dist ../dist",
+    "prepublishOnly": "expo-module prepare && expo-module prepublishOnly && <%- packageManager %> run web:export",
     "web:dev": "cd webui && npx expo start -w",
-    "web:export": "cd webui && npx expo export -p web --output-dir dist && mv dist ../dist"
+    "web:export": "./scripts/build-webui.js"
   },
   "keywords": [
     "expo",
@@ -26,8 +26,10 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@types/react": "<%- typesReactPackageVersion %>",
     "expo": "<%- expoPackageVersion %>",
     "expo-module-scripts": "^4.1.6",
+    "react": "<%- reactPackageVersion %>",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {

--- a/packages/create-dev-plugin/templates/app-adapter/scripts/build-webui.js
+++ b/packages/create-dev-plugin/templates/app-adapter/scripts/build-webui.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const fs = require('fs/promises');
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '..');
+
+async function runAsync() {
+  await spawnAsync('npx', ['expo', 'export', '-p', 'web', '--output-dir', 'dist'], {
+    cwd: path.join(projectRoot, 'webui'),
+  });
+
+  // [1] Remove dist if it exists
+  const distPath = path.join(projectRoot, 'dist');
+  try {
+    await fs.rm(distPath, { recursive: true, force: true });
+  } catch {}
+
+  // [2] Move dist from webui
+  const srcDist = path.join(projectRoot, 'webui', 'dist');
+  await fs.rename(srcDist, distPath);
+}
+
+async function spawnAsync(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit', shell: true, ...options });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${command} process exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+(async () => {
+  try {
+    await runAsync();
+  } catch (error) {
+    console.error('Error during build-webui:', error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
# Why

better create-dev-plugin support and fix issues

# How

- introduce `build-webui.js` to prevent `rm -rf ../dist && mv dist ../dist` in package.json
- add missing `react` and `@types/react` dependencies
- add missing `@expo/metro-runtime` dependency for webui

# Test

test create-dev-plugin to create a plugin