### PR TITLE
[create-dev-plugin] fix EXPO_BETA enabled by default

### DIFF
--- a/packages/create-dev-plugin/src/env.ts
+++ b/packages/create-dev-plugin/src/env.ts
@@ -1,4 +1,3 @@
 import getenv from 'getenv';
 
-// FIXME: disable default BETA when SDK 50 is officially released.
-export const EXPO_BETA = getenv.boolish('EXPO_BETA', true);
+export const EXPO_BETA = getenv.boolish('EXPO_BETA', false);


### PR DESCRIPTION
# Why

fix that we use incorrect template to create the webui project for create-dev-plugin

# How

turn `EXPO_BETA` to disabled by default