### PR TITLE
[create-dev-plugin] fix creating webui project when running on bun

### DIFF
--- a/packages/create-dev-plugin/src/createWebUiProject.ts
+++ b/packages/create-dev-plugin/src/createWebUiProject.ts
@@ -20,9 +20,10 @@ export async function createWebUiProjectAsync(
   const templateVersion = EXPO_BETA ? 'next' : 'latest';
   const template = `expo-template-blank-typescript@${templateVersion}`;
   debug(`Using expo template: ${template}`);
+  const argTerminator = packageManager === 'npm' ? '--' : '';
   await spawnAsync(
     packageManager,
-    ['create', 'expo-app', '--', '--template', template, '--yes', '--no-install', 'webui'],
+    ['create', 'expo-app', argTerminator, '--template', template, '--yes', '--no-install', 'webui'],
     { cwd: projectRoot, stdio: 'ignore' }
   );
 


### PR DESCRIPTION
# Why

fixes
```
✖ Creating the webui project
Error: bun create expo-app -- --template expo-template-blank-typescript@latest --yes --no-install webui exited with non-zero code: 1
    at ChildProcess.completionListener (/private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:2:57083)
    at Object.onceWrapper (node:events:633:26)
    at ChildProcess.emit (node:events:518:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
    ...
    at spawnAsync (/private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:2:56577)
    at createWebUiProjectAsync (/private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:30:27873)
    at /private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:30:32170
    at newStep (/private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:30:36688)
    at runAsync (/private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:30:32095)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async /private/tmp/bunx-501-create-dev-plugin@latest/node_modules/create-dev-plugin/build/index.js:30:33602 {
```

# How

as https://github.com/expo/expo/pull/32963 to only add argument terminator for npm