### PR TITLE
support bun 1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@expo/spawn-async": "^1.7.2",
         "@tsconfig/node20": "^20.1.4",
         "prettier": "^3.3.3",
+        "typescript": "^5.9.2",
       },
     },
     "apps/example": {
@@ -60,6 +61,7 @@
       "version": "0.3.1",
       "devDependencies": {
         "@apollo/client": "^3.11.10",
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "graphql": "^16.9.0",
@@ -67,16 +69,19 @@
       },
       "peerDependencies": {
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
     "packages/apollo-client/webui": {
       "name": "@dev-plugins/apollo-client-webui",
       "version": "0.3.1",
       "devDependencies": {
+        "@ant-design/icons": "^5.5.1",
         "@babel/core": "^7.26.0",
         "@types/react": "~19.0.10",
         "antd": "^5.22.0",
         "expo": "53.0.7",
+        "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-json-view": "^1.21.3",
@@ -90,6 +95,7 @@
       "version": "0.3.1",
       "devDependencies": {
         "@react-native-async-storage/async-storage": "^1.24.0",
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "typescript": "~5.8.3",
@@ -97,6 +103,7 @@
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.0.0",
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
     "packages/async-storage/webui": {
@@ -147,6 +154,7 @@
       "name": "@dev-plugins/react-native-mmkv",
       "version": "0.3.1",
       "devDependencies": {
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "react-native-mmkv": "^3.1.0",
@@ -154,6 +162,7 @@
       },
       "peerDependencies": {
         "expo": ">=53.0.5",
+        "react": "*",
         "react-native-mmkv": "*",
       },
     },
@@ -183,6 +192,7 @@
       },
       "devDependencies": {
         "@react-navigation/core": "^7.0.0",
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "typescript": "~5.8.3",
@@ -190,12 +200,14 @@
       "peerDependencies": {
         "@react-navigation/core": "*",
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
     "packages/react-navigation/webui": {
       "name": "@dev-plugins/react-navigation-webui",
       "version": "0.3.1",
       "devDependencies": {
+        "@ant-design/colors": "^7.1.0",
         "@ant-design/icons": "^5.5.1",
         "@babel/core": "^7.26.0",
         "@emotion/react": "^11.13.3",
@@ -225,6 +237,7 @@
       },
       "devDependencies": {
         "@tanstack/react-query": "^5.59.20",
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "typescript": "~5.8.3",
@@ -232,6 +245,7 @@
       "peerDependencies": {
         "@tanstack/react-query": "*",
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
     "packages/react-query/webui": {
@@ -263,6 +277,7 @@
       "name": "@dev-plugins/tinybase",
       "version": "0.3.1",
       "devDependencies": {
+        "@types/react": "~19.0.10",
         "expo": "53.0.7",
         "expo-module-scripts": "^4.1.7",
         "tinybase": "^5.3.8",
@@ -270,6 +285,7 @@
       },
       "peerDependencies": {
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
     "packages/tinybase/webui": {
@@ -296,6 +312,7 @@
       },
       "peerDependencies": {
         "expo": ">=53.0.5",
+        "react": "*",
       },
     },
   },
@@ -1593,7 +1610,7 @@
 
     "expo-splash-screen": ["expo-splash-screen@31.0.10", "", { "dependencies": { "@expo/prebuild-config": "^54.0.3" }, "peerDependencies": { "expo": "*" } }, "sha512-i6g9IK798mae4yvflstQ1HkgahIJ6exzTCTw4vEdxV0J2SwiW3Tj+CwRjf0te7Zsb+7dDQhBTmGZwdv00VER2A=="],
 
-    "expo-status-bar": ["expo-status-bar@3.0.8", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw=="],
+    "expo-status-bar": ["expo-status-bar@2.2.3", "", { "dependencies": { "react-native-edge-to-edge": "1.6.0", "react-native-is-edge-to-edge": "^1.1.6" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-+c8R3AESBoduunxTJ8353SqKAKpxL6DvcD8VKBuh81zzJyUUbfB4CVjr1GufSJEKsMzNPXZU+HJwXx7Xh7lx8Q=="],
 
     "expo-system-ui": ["expo-system-ui@6.0.7", "", { "dependencies": { "@react-native/normalize-colors": "0.81.4", "debug": "^4.3.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-NT+/r/BOg08lFI9SZO2WFi9X1ZmawkVStknioWzQq6Mt4KinoMS6yl3eLbyOLM3LoptN13Ywfo4W5KHA6TV9Ow=="],
 
@@ -2373,6 +2390,8 @@
 
     "react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
 
+    "react-native-edge-to-edge": ["react-native-edge-to-edge@1.6.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og=="],
+
     "react-native-gesture-handler": ["react-native-gesture-handler@2.28.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.2.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q=="],
@@ -2693,7 +2712,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.6", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "has-proto": "^1.0.3", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0" } }, "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.39", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw=="],
 
@@ -3145,6 +3164,30 @@
 
     "@callstack/react-theme-provider/deepmerge": ["deepmerge@3.3.0", "", {}, "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="],
 
+    "@dev-plugins/apollo-client/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/apollo-client-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/async-storage/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/async-storage-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-native-mmkv/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-native-mmkv-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-navigation/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-navigation-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-query/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/react-query-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/tinybase/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@dev-plugins/tinybase-webui/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
     "@emotion/babel-plugin/@babel/helper-module-imports": ["@babel/helper-module-imports@7.25.9", "", { "dependencies": { "@babel/traverse": "^7.25.9", "@babel/types": "^7.25.9" } }, "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw=="],
 
     "@emotion/babel-plugin/@emotion/hash": ["@emotion/hash@0.9.2", "", {}, "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="],
@@ -3413,11 +3456,13 @@
 
     "example/@types/react": ["@types/react@19.1.17", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA=="],
 
-    "example/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "example/expo-status-bar": ["expo-status-bar@3.0.8", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw=="],
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "expo-module-scripts/babel-preset-expo": ["babel-preset-expo@13.1.11", "", { "dependencies": { "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/preset-react": "^7.22.15", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-preset": "0.79.2", "babel-plugin-react-native-web": "~0.19.13", "babel-plugin-syntax-hermes-parser": "^0.25.1", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4", "react-refresh": "^0.14.2", "resolve-from": "^5.0.0" }, "peerDependencies": { "babel-plugin-react-compiler": "^19.0.0-beta-e993439-20250405" }, "optionalPeers": ["babel-plugin-react-compiler"] }, "sha512-jigWjvhRVdm9UTPJ1wjLYJ0OJvD5vLZ8YYkEknEl6+9S1JWORO/y3xtHr/hNj5n34nOilZqdXrmNFcqKc8YTsg=="],
+
+    "expo-module-scripts/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@expo/spawn-async": "^1.7.2",
     "@tsconfig/node20": "^20.1.4",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/apollo-client/package.json
+++ b/packages/apollo-client/package.json
@@ -37,12 +37,14 @@
   "dependencies": {},
   "devDependencies": {
     "@apollo/client": "^3.11.10",
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "graphql": "^16.9.0",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/apollo-client/webui/babel.config.js
+++ b/packages/apollo-client/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/apollo-client/webui/package.json
+++ b/packages/apollo-client/webui/package.json
@@ -11,10 +11,12 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@ant-design/icons": "^5.5.1",
     "@babel/core": "^7.26.0",
     "@types/react": "~19.0.10",
     "antd": "^5.22.0",
     "expo": "53.0.7",
+    "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-json-view": "^1.21.3",

--- a/packages/async-storage/package.json
+++ b/packages/async-storage/package.json
@@ -34,12 +34,14 @@
   "license": "MIT",
   "devDependencies": {
     "@react-native-async-storage/async-storage": "^1.24.0",
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": "^1.0.0",
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/async-storage/webui/babel.config.js
+++ b/packages/async-storage/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/create-dev-plugin/templates/app-adapter/package.json
+++ b/packages/create-dev-plugin/templates/app-adapter/package.json
@@ -34,6 +34,7 @@
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react": "*"
   }
 }

--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -34,6 +34,7 @@
   "author": "cyrilbo",
   "license": "MIT",
   "devDependencies": {
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "react-native-mmkv": "^3.1.0",
@@ -41,6 +42,7 @@
   },
   "peerDependencies": {
     "react-native-mmkv": "*",
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/react-native-mmkv/webui/babel.config.js
+++ b/packages/react-native-mmkv/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/react-navigation/package.json
+++ b/packages/react-navigation/package.json
@@ -39,12 +39,14 @@
   },
   "devDependencies": {
     "@react-navigation/core": "^7.0.0",
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "@react-navigation/core": "*",
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/react-navigation/webui/babel.config.js
+++ b/packages/react-navigation/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/react-navigation/webui/package.json
+++ b/packages/react-navigation/webui/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@ant-design/colors": "^7.1.0",
     "@ant-design/icons": "^5.5.1",
     "@babel/core": "^7.26.0",
     "@emotion/react": "^11.13.3",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -39,12 +39,14 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.59.20",
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
     "@tanstack/react-query": "*",
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/react-query/webui/babel.config.js
+++ b/packages/react-query/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/tinybase/package.json
+++ b/packages/tinybase/package.json
@@ -35,12 +35,14 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "@types/react": "~19.0.10",
     "expo": "53.0.7",
     "expo-module-scripts": "^4.1.7",
     "tinybase": "^5.3.8",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }

--- a/packages/tinybase/webui/babel.config.js
+++ b/packages/tinybase/webui/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-  };
-};

--- a/packages/vanilla-log-viewer/package.json
+++ b/packages/vanilla-log-viewer/package.json
@@ -25,6 +25,7 @@
     "expo": "53.0.7"
   },
   "peerDependencies": {
-    "expo": ">=53.0.5"
+    "expo": ">=53.0.5",
+    "react": "*"
   }
 }


### PR DESCRIPTION
# Why

bun 1.3 uses isolated modules by default and then some errors happen because of missing dependencies

# How

- add missing devDeps and peerDeps
- remove `**/webui/babel.config.js` to fix no `babel-preset-expo` as dependencies. we don't need these default babel.config.js and can just use the builtin from expo-cli

# Test Plan

use bun 1.3 and run `bun i` on monorepo root