### PR TITLE
Add mmkv v4 support for MMKV dev tools 

### DIFF
--- a/packages/react-native-mmkv/package.json
+++ b/packages/react-native-mmkv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev-plugins/react-native-mmkv",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Expo DevTools Plugin for react-native-mmkv",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -35,9 +35,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/react": "~19.0.10",
-    "expo": "53.0.7",
+    "expo": "^54.0.0",
     "expo-module-scripts": "^4.1.7",
-    "react-native-mmkv": "^3.1.0",
+    "react-native-mmkv": "^4.0.0",
     "typescript": "~5.8.3"
   },
   "peerDependencies": {

--- a/packages/react-native-mmkv/src/useMMKVDevTools.ts
+++ b/packages/react-native-mmkv/src/useMMKVDevTools.ts
@@ -1,6 +1,6 @@
 import { useDevToolsPluginClient, type EventSubscription } from 'expo/devtools';
 import { useCallback, useEffect } from 'react';
-import { MMKV } from 'react-native-mmkv';
+import { createMMKV } from 'react-native-mmkv';
 
 import { Method } from '../methods';
 
@@ -16,7 +16,7 @@ import { Method } from '../methods';
  */
 export function useMMKVDevTools({
   errorHandler,
-  storage = new MMKV(),
+  storage = createMMKV();
 }: {
   errorHandler?: (error: Error) => void;
   storage?: MMKV;
@@ -83,7 +83,7 @@ export function useMMKVDevTools({
       subscriptions.push(
         on('remove', async ({ key }) => {
           if (key !== undefined) {
-            storage.delete(key);
+            storage.remove(key);
           }
         })
       );


### PR DESCRIPTION
This pull request updates the `@dev-plugins/react-native-mmkv` package to support the latest versions of its dependencies and aligns the code with breaking changes in the `react-native-mmkv` API. The main focus is on upgrading to `react-native-mmkv` v4 and updating the usage of its API in the codebase.

Dependency upgrades:

* Upgraded `react-native-mmkv` from `^3.1.0` to `^4.0.0` in `package.json`, and updated `expo` to `^54.0.0` to ensure compatibility with the latest ecosystem.
* Bumped the package version from `0.4.0` to `0.4.1` to reflect these changes.

Code changes for `react-native-mmkv` v4 compatibility:

* Replaced the deprecated `MMKV` constructor with the new `createMMKV` factory function in `useMMKVDevTools.ts`. [[1]](diffhunk://#diff-93c95f5e1b9144328d9208e7db9bb11eb5edc93ba2ed8f32b4eab325691c3da0L3-R3) [[2]](diffhunk://#diff-93c95f5e1b9144328d9208e7db9bb11eb5edc93ba2ed8f32b4eab325691c3da0L19-R19)
* Updated the storage removal method from `delete` to `remove` to match the new API in `react-native-mmkv` v4.